### PR TITLE
Fix generator comment in prism logo SVG

### DIFF
--- a/images/logo_prisma_prismatic_dylan_weber_prism.svg
+++ b/images/logo_prisma_prismatic_dylan_weber_prism.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 28.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 28.0.0, SVG Export Plug-In. SVG Version: 6.00 Build 0) -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 2048 2048" style="enable-background:new 0 0 2048 2048;" xml:space="preserve">
 <style type="text/css">


### PR DESCRIPTION
## Summary
- fix spacing in the `logo_prisma_prismatic_dylan_weber_prism.svg` comment

## Testing
- `grep -n "  " images/logo_prisma_prismatic_dylan_weber_prism.svg | head`

------
https://chatgpt.com/codex/tasks/task_e_684702ed19648327aede4b3aa321f33d